### PR TITLE
chore: promote spring-demo to version 0.0.9

### DIFF
--- a/config-root/namespaces/jx-staging/spring-demo/spring-demo-spring-demo-deploy.yaml
+++ b/config-root/namespaces/jx-staging/spring-demo/spring-demo-spring-demo-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: spring-demo-spring-demo
   labels:
     draft: draft-app
-    chart: "spring-demo-0.0.7"
+    chart: "spring-demo-0.0.9"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'spring-demo'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: spring-demo-spring-demo
       containers:
         - name: spring-demo
-          image: "ghcr.io/babadofar/spring-demo:0.0.7"
+          image: "ghcr.io/babadofar/spring-demo:0.0.9"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.7
+              value: 0.0.9
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/spring-demo/spring-demo-svc.yaml
+++ b/config-root/namespaces/jx-staging/spring-demo/spring-demo-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: spring-demo
   labels:
-    chart: "spring-demo-0.0.7"
+    chart: "spring-demo-0.0.9"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'spring-demo'

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@
 	    <tr>
 	      <td>spring-demo</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> spring-demo</td>
-	      <td>0.0.7</td>
+	      <td>0.0.9</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -133,14 +133,14 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.7
+    appVersion: 0.0.9
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-09-09T23:03:52Z"
+    firstDeployed: "2022-09-10T11:01:43Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-09-09T23:03:52Z"
+    lastDeployed: "2022-09-10T11:01:43Z"
     name: spring-demo
     releaseName: spring-demo
     repositoryName: dev
     repositoryUrl: https://babadofar.github.io/jx3-k3s-vault-demo/
     resourcePath: config-root/namespaces/jx-staging/spring-demo
-    version: 0.0.7
+    version: 0.0.9

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://babadofar.github.io/jx3-k3s-vault-demo/
 releases:
 - chart: dev/spring-demo
-  version: 0.0.7
+  version: 0.0.9
   name: spring-demo
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote spring-demo to version 0.0.9

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
