### PR TITLE
chore: promote node-demo to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/node-demo/node-demo-ingress.yaml
+++ b/config-root/namespaces/jx-staging/node-demo/node-demo-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: node-demo/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'node-demo'
+  name: node-demo
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: node-demo
+                port:
+                  number: 80
+      host: node-demo.jx-staging.192.168.64.2.nip.io

--- a/config-root/namespaces/jx-staging/node-demo/node-demo-node-demo-deploy.yaml
+++ b/config-root/namespaces/jx-staging/node-demo/node-demo-node-demo-deploy.yaml
@@ -1,0 +1,68 @@
+# Source: node-demo/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-demo-node-demo
+  labels:
+    draft: draft-app
+    chart: "node-demo-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'node-demo'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: node-demo-node-demo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: node-demo-node-demo
+    spec:
+      serviceAccountName: node-demo-node-demo
+      volumes:
+        - name: config-volume
+          configMap:
+            name: configjs
+      containers:
+        - name: node-demo
+          image: "ghcr.io/babadofar/node-demo:0.0.2"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config-volume
+              mountPath: /usr/src/app/config
+          env:
+            - name: VERSION
+              value: 0.0.2
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1
+              memory: 1524Mi
+            requests:
+              cpu: 0.1
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/node-demo/node-demo-node-demo-sa.yaml
+++ b/config-root/namespaces/jx-staging/node-demo/node-demo-node-demo-sa.yaml
@@ -1,0 +1,10 @@
+# Source: node-demo/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-demo-node-demo
+  annotations:
+    meta.helm.sh/release-name: 'node-demo'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/node-demo/node-demo-svc.yaml
+++ b/config-root/namespaces/jx-staging/node-demo/node-demo-svc.yaml
@@ -1,0 +1,20 @@
+# Source: node-demo/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-demo
+  labels:
+    chart: "node-demo-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'node-demo'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: node-demo-node-demo

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,13 @@
 	      <td></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td>node-demo</td>
+	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> node-demo</td>
+	      <td>0.0.2</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -144,3 +144,15 @@
     repositoryUrl: https://babadofar.github.io/jx3-k3s-vault-demo/
     resourcePath: config-root/namespaces/jx-staging/spring-demo
     version: 0.0.10
+  - apiVersion: v1
+    appVersion: 0.0.2
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-09-10T13:11:51Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-09-10T13:11:51Z"
+    name: node-demo
+    releaseName: node-demo
+    repositoryName: dev
+    repositoryUrl: https://babadofar.github.io/jx3-k3s-vault-demo/
+    resourcePath: config-root/namespaces/jx-staging/node-demo
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: spring-demo
   values:
   - jx-values.yaml
+- chart: dev/node-demo
+  version: 0.0.2
+  name: node-demo
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/node-demo
   version: 0.0.2
   name: node-demo
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-demo to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
